### PR TITLE
[Tools] Handle countdown rounds with no points possible

### DIFF
--- a/resources/tools/countdown.js
+++ b/resources/tools/countdown.js
@@ -74,7 +74,7 @@ class SolutionStep {
 class Solver {
 
 	static #shortestSolutionDistance = 11;
-	static #shortestSolutionSteps;
+	static #shortestSolutionSteps = false;
 
 	#target;
 	#asSteps;
@@ -278,9 +278,12 @@ const onLoad = () => {
 			solver.trySolve();
 			const result = Solver.getSolution();
 
-			outputElem.innerText = '';
-			outputElem.innerText = 'Found: ' + result.getValue();
-			outputElem.innerText += '\n= ' + result.getHistory();
+			if ( result === false ) {
+				outputElem.innerText = 'NO SOLUTIONS WITHIN 10 OF ANSWER!';
+			} else {
+				outputElem.innerText = 'Found: ' + result.getValue();
+				outputElem.innerText += '\n= ' + result.getHistory();
+			}
 		}
 	);
 };


### PR DESCRIPTION
Points can only be scored if within 10 of the target value, which is why `Solver#shortestSolutionDistance` starts at 11. But, sometimes it is impossible to get even within 10 of the target value, e.g. during the last numbers round of "8 Out of 10 Cats Does Countdown" series 11 episode 5, where the target was 950 and the numbers were 1, 10, 2, 3, 5, and 2. In such a case, the code previously tried to call `getValue()` on `undefined`. Now, if there is no solution that can earn points, `Solver.getSolution()` will return false, and the rendering will show an error message about the round being impossible.