### PR TITLE
[Tests] Expand test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
 			"DanielWebsite\\": "src/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"DanielWebsite\\Tests\\": "tests/"
+		}
+	},
 	"scripts": {
 		"post-update-cmd": "echo 'Deny from all' > vendor/.htaccess",
 		"parallel-lint": "parallel-lint . --exclude vendor",

--- a/tests/Blog/BlogDisplayTest.php
+++ b/tests/Blog/BlogDisplayTest.php
@@ -1,0 +1,91 @@
+<?php
+declare( strict_types = 1 );
+
+namespace DanielWebsite\Tests\Blog;
+
+use DanielEScherzer\CommonMarkPygmentsHighlighter\PygmentsHighlighterExtension;
+use DanielWebsite\Blog\BlogDisplay;
+use DanielWebsite\Blog\BlogPost;
+use DanielWebsite\Tests\TraversableContainsInstanceOf;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\Extension\Footnote\FootnoteExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass( BlogDisplay::class )]
+class BlogDisplayTest extends TestCase {
+
+	#[DataProvider( 'provideExtensionCases' ) ]
+	public function testExtensions( ?string $markdown, array $classes ) {
+		$post = false;
+		if ( $markdown !== null ) {
+			$post = new BlogPost( '20251201-testing', $markdown );
+		}
+		$env = BlogDisplay::makeCommonMarkEnv( $post );
+		$extensions = $env->getExtensions();
+		$this->assertSameSize( $classes, $extensions );
+		foreach ( $classes as $class ) {
+			$this->assertContainsInstanceOf(
+				$class,
+				$extensions
+			);
+		}
+	}
+
+	public static function provideExtensionCases() {
+		$defaultExts = [
+			CommonMarkCoreExtension::class,
+			ExternalLinkExtension::class,
+			FrontMatterExtension::class,
+		];
+		yield 'Defaults, no post' => [ null, $defaultExts ];
+		yield 'Defaults, empty post' => [ '', $defaultExts ];
+		yield 'Defaults, no yaml' => [ '# Demo', $defaultExts ];
+		yield 'Defaults, yaml with no extensions' => [
+			"---\nTitle: Example\n---\n# Demo",
+			$defaultExts,
+		];
+		yield 'YAML loads TOC' => [
+			"---\nextensions:\n  toc: true\n---\n# Demo",
+			[
+				...$defaultExts,
+				HeadingPermaLinkExtension::class,
+				TableOfContentsExtension::class,
+			],
+		];
+		yield 'YAML loads pygments' => [
+			"---\nextensions:\n  pygments: true\n---\n# Demo",
+			[ ...$defaultExts, PygmentsHighlighterExtension::class ],
+		];
+		yield 'YAML loads footnotes' => [
+			"---\nextensions:\n  footnotes: true\n---\n# Demo",
+			[ ...$defaultExts, FootnoteExtension::class ],
+		];
+		yield 'YAML loads all' => [
+			"---\nextensions:\n  toc: true\n  pygments: true\n  footnotes: true\n---\n# Demo",
+			[
+				...$defaultExts,
+				HeadingPermaLinkExtension::class,
+				TableOfContentsExtension::class,
+				PygmentsHighlighterExtension::class,
+				FootnoteExtension::class,
+			],
+		];
+	}
+
+	public static function assertContainsInstanceOf(
+		string $type,
+		iterable $haystack,
+		string $message = ''
+	): void {
+		$constraint = new TraversableContainsInstanceOf( $type );
+
+		self::assertThat( $haystack, $constraint, $message );
+	}
+
+}

--- a/tests/SitemapGeneratorTest.php
+++ b/tests/SitemapGeneratorTest.php
@@ -6,11 +6,13 @@ namespace DanielWebsite\Tests;
 /**
  * Tests that the sitemap is up to date
  */
+use DanielWebsite\SiteMapEntry;
 use DanielWebsite\SitemapGenerator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass( SitemapGenerator::class )]
+#[CoversClass( SiteMapEntry::class )]
 class SitemapGeneratorTest extends TestCase {
 
 	private const TEST_FILE_LOCATION = __DIR__ . '/sitemap.xml';

--- a/tests/StaticOutputTest.php
+++ b/tests/StaticOutputTest.php
@@ -15,6 +15,7 @@ use DanielWebsite\Pages\Error404Page;
 use DanielWebsite\Pages\Error405Page;
 use DanielWebsite\Pages\LandingPage;
 use DanielWebsite\Pages\OpenSourcePage;
+use DanielWebsite\Pages\RedirectPage;
 use DanielWebsite\Pages\ThesisPage;
 use DanielWebsite\Pages\ToolPage;
 use DanielWebsite\Pages\WorkPage;
@@ -31,6 +32,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass( Error405Page::class )]
 #[CoversClass( LandingPage::class )]
 #[CoversClass( OpenSourcePage::class )]
+#[CoversClass( RedirectPage::class )]
 #[CoversClass( ThesisPage::class )]
 #[CoversClass( ToolPage::class ) ]
 #[CoversClass( WorkPage::class )]
@@ -80,6 +82,11 @@ class StaticOutputTest extends TestCase {
 
 		// Error 405
 		yield 'POST work page' => [ 'POST', '/Work', 'NoPost.html' ];
+	}
+
+	public function testRedirect() {
+		$page = Router::pageForRequest( 'GET', '/Resume' );
+		$this->assertInstanceOf( RedirectPage::class, $page );
 	}
 
 }

--- a/tests/TraversableContainsInstanceOf.php
+++ b/tests/TraversableContainsInstanceOf.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types = 1 );
+
+namespace DanielWebsite\Tests;
+
+use PHPUnit\Framework\Constraint\TraversableContains;
+
+class TraversableContainsInstanceOf extends TraversableContains {
+
+	private string $type;
+
+	public function __construct( string $type ) {
+		$this->type = $type;
+	}
+
+	protected function matches( mixed $other ): bool {
+		foreach ( $other as $element ) {
+			if ( $element instanceof $this->type ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public function toString(): string {
+		return 'contains an instance of "' . $this->type . '"';
+	}
+}


### PR DESCRIPTION
Add unit tests for the extensions that `BlogDisplay::makeCommonMarkEnv()` adds, test that RedirectPage instances are returned by `Router::pageForRequest()` for redirect pages, and note that the sitemap generator test also tests the sitemap attribute.