### PR TITLE
[Blog] Link to PHP 8.5.6RC3 announcement

### DIFF
--- a/src/Blog/posts/20260430-php856-rc-3.md
+++ b/src/Blog/posts/20260430-php856-rc-3.md
@@ -10,8 +10,8 @@ I have previously had to skip a non-stable release
 ([PHP 8.5.0 alpha3][blog-alpha3]), and to create an extra unplanned release
 candidate ([PHP 8.5.0 RC5][blog-rc5]). For PHP 8.5.6 release candidate 3, I had
 to do both: release candidate 2 was unplanned, and then an error led to skipping
-it, resulting in release candidate 3 that I just announced. Here is what
-happened.
+it, resulting in release candidate 3 that I [just announced][rc3-announce].
+Here is what happened.
 
 ![PHP 8.5.6RC3 confusion](/resources/php-8.5.6RC3-confusion.svg)
 
@@ -70,6 +70,7 @@ next week.
 [gh-21911]: https://github.com/php/php-src/issues/21911
 [lexbor-lib]: https://lexbor.com/
 [rc1-announce]: https://news-web.php.net/php.internals/130688
+[rc3-announce]: https://news-web.php.net/php.internals/130721
 [CVE-2026-42371]: https://nvd.nist.gov/vuln/detail/CVE-2026-42371
 [php-sec-policy]: https://github.com/php/policies/blob/67fbca9739e3de9823c297cdb9a938e3b532be93/security-classification.rst#handling-issues
 [uri-disclosure]: https://www.openwall.com/lists/oss-security/2026/04/27/2

--- a/tests/data/Home.html
+++ b/tests/data/Home.html
@@ -8,5 +8,5 @@ experience.</p><h2 class="subsection-header">Contact</h2><ul><li><a href="https:
 (<a href="./Blog/20250801-no-alpha-3">PHP 8.5.0 alpha3</a>), and to create an extra unplanned release
 candidate (<a href="./Blog/20251113-release-candidate-5">PHP 8.5.0 RC5</a>). For PHP 8.5.6 release candidate 3, I had
 to do both: release candidate 2 was unplanned, and then an error led to skipping
-it, resulting in release candidate 3 that I just announced. Here is what
-happened. <a href="/Blog/20260430-php856-rc-3">Continue reading...</a></p></div></div><div class="des-footer"><div class="des-footer--content">Content is © 2026 Daniel Scherzer</div></div></body></html>
+it, resulting in release candidate 3 that I <a rel="noopener noreferrer" target="_blank" class="external-link" href="https://news-web.php.net/php.internals/130721">just announced</a>.
+Here is what happened. <a href="/Blog/20260430-php856-rc-3">Continue reading...</a></p></div></div><div class="des-footer"><div class="des-footer--content">Content is © 2026 Daniel Scherzer</div></div></body></html>

--- a/tests/data/blog-index.html
+++ b/tests/data/blog-index.html
@@ -3,8 +3,8 @@
 (<a href="./Blog/20250801-no-alpha-3">PHP 8.5.0 alpha3</a>), and to create an extra unplanned release
 candidate (<a href="./Blog/20251113-release-candidate-5">PHP 8.5.0 RC5</a>). For PHP 8.5.6 release candidate 3, I had
 to do both: release candidate 2 was unplanned, and then an error led to skipping
-it, resulting in release candidate 3 that I just announced. Here is what
-happened. <a href="/Blog/20260430-php856-rc-3">Continue reading...</a></p></div><div class="blog-preview"><h2>PHP 8.6 Release Manager</h2><span class="blog-preview-date">Thursday, 16 April 2026</span><p>I'm excited to announce that I will be serving as the &quot;veteran&quot; release manager
+it, resulting in release candidate 3 that I <a rel="noopener noreferrer" target="_blank" class="external-link" href="https://news-web.php.net/php.internals/130721">just announced</a>.
+Here is what happened. <a href="/Blog/20260430-php856-rc-3">Continue reading...</a></p></div><div class="blog-preview"><h2>PHP 8.6 Release Manager</h2><span class="blog-preview-date">Thursday, 16 April 2026</span><p>I'm excited to announce that I will be serving as the &quot;veteran&quot; release manager
 for the PHP 8.6 release cycle. In that role I will be mentoring two new
 &quot;rookie&quot; release managers to ensure a smooth and successful release process. <a href="/Blog/20260416-php86-release-manager">Continue reading...</a></p></div><div class="blog-preview"><h2>Introducing define_deprecated() for PHP</h2><span class="blog-preview-date">Friday, 10 April 2026</span><p>In PHP 8.5, I introduced support for <a href="./Blog/20250429-attributes-on-constants">attributes on constants</a>,
 which allows marking compile-time global constants as deprecated. However,


### PR DESCRIPTION
Unlike pre-GA releases there was no announcement on php.net, so the only link I could use is to one of the emails; for the emails to link to the blog post, I needed the original blog post not to link to the emails to resolve the gordian knot.